### PR TITLE
feat(module): add option to enable/disable global app middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ export default defineNuxtConfig({
       "Internet Explorer": null,
       "Unknown Browser": 12,
     },
+    globalAppMiddleware: true,
   },
 })
 ```

--- a/src/module.ts
+++ b/src/module.ts
@@ -16,8 +16,9 @@ export type MinimumBrowsersVersion = {
 } & Record<string, AcceptedValues>;
 
 export interface ModuleOptions {
-  redirect: string;
-  versions: MinimumBrowsersVersion;
+  redirect?: string;
+  versions?: MinimumBrowsersVersion;
+  globalAppMiddleware?: boolean
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -36,9 +37,18 @@ export default defineNuxtModule<ModuleOptions>({
       },
     },
   },
-
+  defaults: {
+    globalAppMiddleware: true
+  },
   setup(options, nuxt) {
     const resolver = createResolver(import.meta.url);
+
+    if (!options.versions || !options.redirect) {
+      console.warn(
+        "[Nuxt Supported browsers]: module options are required, module is disabled"
+      );
+      return;
+    }
 
     nuxt.options.runtimeConfig.public.supportedBrowsers = defu(
       nuxt.options.runtimeConfig.public.supportedBrowsers,

--- a/src/runtime/middleware/supported-browsers.ts
+++ b/src/runtime/middleware/supported-browsers.ts
@@ -9,13 +9,6 @@ export default defineNuxtRouteMiddleware((to) => {
     supportedBrowsers: { versions, redirect },
   } = useRuntimeConfig().public;
 
-  if (!versions || !redirect) {
-    console.warn(
-      "[Nuxt Supported browsers]: module options are required, module is disabled"
-    );
-    return;
-  }
-
   const isUnsuportedPage: boolean = to.path === redirect;
 
   const { name, version } = useDetectBrowser(navigator.userAgent);

--- a/src/runtime/plugin.ts
+++ b/src/runtime/plugin.ts
@@ -1,7 +1,9 @@
-import { defineNuxtPlugin, addRouteMiddleware } from "#app";
+import { defineNuxtPlugin, addRouteMiddleware, useRuntimeConfig } from "#app";
 import supportedBrowsers from "./middleware/supported-browsers";
 
 export default defineNuxtPlugin(() => {
-  const global = { global: true };
-  addRouteMiddleware("supportedBrowsers", supportedBrowsers, global);
+  const { globalAppMiddleware } = useRuntimeConfig().public.supportedBrowsers
+  addRouteMiddleware("supportedBrowsers", supportedBrowsers, {
+    global: globalAppMiddleware
+  });
 });


### PR DESCRIPTION
Add new option `globalAppMiddleware` to enable/disable global app middleware.
If global is disabled, it can be enabled per page by adding `definePageMeta({ middleware: 'supportedBrowsers' })`